### PR TITLE
Update

### DIFF
--- a/lib/res_extended.js
+++ b/lib/res_extended.js
@@ -7,14 +7,17 @@ module.exports = () => {
         const response = {};
         const orig_send = res.send;
 
-        res.warn = (status, error) => {
-            if (typeof error === 'undefined' ) {
-                error = status;
+        res.warn = (status) => {
+            if (typeof status === 'undefined') {
                 status = 400;
             }
 
+            if (!response.errors) {
+                throw new Error('No errors to warn for');
+            }
+
             res.status(status)
-                .send(error);
+                .send({errors: response.errors});
         };
 
         res.send = (data) => {
@@ -59,7 +62,7 @@ module.exports = () => {
 
             if (Array.isArray(args.value)) {
                 response.data[args.key] = response.data[args.key].concat(args.value);
-            } 
+            }
             else {
                 response.data[args.key].push(args.value);
             }
@@ -107,7 +110,7 @@ module.exports = () => {
 
                 key = args[0];
                 value = args[1];
-            } 
+            }
             else {
                 value = args[0];
             }


### PR DESCRIPTION
- Do not override status if error inexistent
- Do not allow warn if no errors existing
- Do not return just a string on calling res.warn, return errors.