### PR TITLE
fix when sample is an array with nested objects

### DIFF
--- a/helpers/util.js
+++ b/helpers/util.js
@@ -39,9 +39,10 @@ function get_data (sample, source, ref) {
 
     if (Array.isArray(sample)) {
         temp = source.map((a, index) => {
-            const ret = validate_primitive_value(sample, 0, source, index, ref + `[${index}]`);
-            has_error = ret instanceof Error ? ret : false;
-            return ret;
+            const ret = get_data(sample[0], source[index], ref + `[${index}]`);
+            if (ret instanceof Error) {
+                has_error = ret;
+            }
         });
 
         return has_error

--- a/helpers/util.js
+++ b/helpers/util.js
@@ -43,6 +43,7 @@ function get_data (sample, source, ref) {
             if (ret instanceof Error) {
                 has_error = ret;
             }
+            return ret;
         });
 
         return has_error


### PR DESCRIPTION
const data = get_data([{
            name: '',
            age: 1, 
            admin: true,
            _skype: ''
        }], req.body)

when you pass:
[
	{
		"name": "a",
		"admin": true
	},
	{
		"name": "b",
		"age": 1,
		"admin": true
	}
]

the return data becomes:
[ Error: [0].age is missing .....,
 { name: 'b', age: 1, admin: true } ]

this also happens when other property is an array of objects.


