### PR TITLE
Dev-1776 Node Boilerplate > Grunt > Bug on test-watch

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,6 @@
 {
     "browser": true,
-    "esnext": true,
+    "esversion": 6,
     "globals": {},
     "globalstrict": true,
     "quotmark": "single",

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,8 +76,7 @@ module.exports = (grunt) => {
     grunt.loadNpmTasks('grunt-env');
 
     grunt.registerTask('test', ['env:test', 'jshint', 'mochaTest']);
-    grunt.registerTask('serve', ['env:dev', 'express']);
-    grunt.registerTask('test-watch', ['env:test', 'jshint', 'mochaTest', 'watch:test']);
+    grunt.registerTask('dev-tests', ['env:dev', 'jshint', 'mochaTest', 'watch:test']);
     grunt.registerTask('default', ['env:dev', 'jshint', 'express', 'watch:express']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -67,7 +67,7 @@ module.exports = (grunt) => {
     grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-env');
 
-    grunt.registerTask('test', ['env:test', 'jshint', 'mochaTest']);
+    grunt.registerTask('test', ['env:test', 'jshint', 'express', 'mochaTest']);
     grunt.registerTask('serve', ['env:dev', 'express']);
     grunt.registerTask('test-watch', ['env:test', 'jshint', 'express', 'mochaTest', 'watch']);
     grunt.registerTask('default', ['env:dev', 'jshint', 'express', 'watch']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,18 @@ module.exports = (grunt) => {
                 spawn: false
             }
           }
+        },
+
+        env: {
+            dev: {
+                NODE_ENV: 'development'
+            },
+            prod: {
+                NODE_NEV: 'production'
+            },
+            test: {
+                NODE_ENV: 'test'
+            }
         }
     });
 
@@ -53,10 +65,11 @@ module.exports = (grunt) => {
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-express-server');
     grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-env');
 
-    grunt.registerTask('test', ['jshint', 'mochaTest']);
-    grunt.registerTask('serve', ['express']);
-    grunt.registerTask('test-watch', ['jshint', 'mochaTest', 'watch']);
-    grunt.registerTask('default', ['jshint', 'express', 'watch']);
+    grunt.registerTask('test', ['env:test', 'jshint', 'mochaTest']);
+    grunt.registerTask('serve', ['env:dev', 'express']);
+    grunt.registerTask('test-watch', ['env:test', 'jshint', 'express', 'mochaTest', 'watch']);
+    grunt.registerTask('default', ['env:dev', 'jshint', 'express', 'watch']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,7 +25,8 @@ module.exports = (grunt) => {
                 src: ['test/**/*.js'],
                 options: {
                     reporter: 'spec',
-                    timeout: 5000
+                    timeout: 5000,
+                    clearRequireCache: true,
                 }
             }
         },
@@ -39,13 +40,20 @@ module.exports = (grunt) => {
         },
 
         watch: {
-          express: {
-            files: ['<%= jshint.files %>'],
-            tasks: ['jshint', 'express'],
-            options: {
-                spawn: false
+            express: {
+                files: ['<%= jshint.files %>'],
+                tasks: ['jshint', 'express'],
+                options: {
+                    spawn: false,
+                },
+            },
+            test: {
+                files: ['<%= jshint.files %>'],
+                tasks: ['jshint', 'mochaTest'],
+                options: {
+                    spawn: false,
+                },
             }
-          }
         },
 
         env: {
@@ -67,9 +75,9 @@ module.exports = (grunt) => {
     grunt.loadNpmTasks('grunt-mocha-test');
     grunt.loadNpmTasks('grunt-env');
 
-    grunt.registerTask('test', ['env:test', 'jshint', 'express', 'mochaTest']);
+    grunt.registerTask('test', ['env:test', 'jshint', 'mochaTest']);
     grunt.registerTask('serve', ['env:dev', 'express']);
-    grunt.registerTask('test-watch', ['env:test', 'jshint', 'express', 'mochaTest', 'watch']);
-    grunt.registerTask('default', ['env:dev', 'jshint', 'express', 'watch']);
+    grunt.registerTask('test-watch', ['env:test', 'jshint', 'mochaTest', 'watch:test']);
+    grunt.registerTask('default', ['env:dev', 'jshint', 'express', 'watch:express']);
 
 };

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project **strictly** uses the [company's JS conventions](https://github.com
   ```sh
   npm install -g grunt-cli
   npm install
-  grunt
+  grunt #or npm run dev-server
   ```
 
 5. check http://localhost:<config.app.PORT>
@@ -247,9 +247,9 @@ grunt test
 ## Test Driven Development (TDD)
 - Use npm scripts or grunt tasks that watches the tests.
 ```sh
-npm test-dev
+npm run dev-tests
 # or
-grunt test-watch
+grunt dev-tests
 ```
 
 ## Code coverage

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ This project **strictly** uses the [company's JS conventions](https://github.com
   grunt
   ```
 
-5. check http://localhost
-6. Update package.json repository link
+5. check http://localhost:<config.app.PORT>
+6. Update package.json details
 7. Update config/config.js
-8. Don't forget tp.
+8. Don't forget to pull.
 
 
 Creating a controller
@@ -59,8 +59,11 @@ Here's a typical controller:
 ```javascript
 // user.js
 
-const util   = require(__dirname + '/../helpers/util'),
-const mysql  = require('anytv-node-mysql'),
+require('app-module-path/register');
+
+const util   = require('../helpers/util');
+const mysql  = require('anytv-node-mysql');
+const squel  = require('squel');
 const moment = require('moment');
 
 
@@ -87,12 +90,14 @@ exports.update_user = (req, res, next) => {
         id = data.user_id;
         delete data.user_id;
 
+        const query = squel.update()
+            .table('users')
+            .setFields(data)
+            .where('user_id = ?', id)
+            .limit(1);
+        
         mysql.use('my_db')
-            .query(
-                'UPDATE users SET ? WHERE user_id = ? LIMIT 1;',
-                [data, id],
-                send_response
-            )
+            .squel(query, send_response)
             .end();
     }
 
@@ -102,7 +107,7 @@ exports.update_user = (req, res, next) => {
             return next(err);
         }
 
-        res.send({message: 'User successfully updated'});
+        res.send({ message: 'User successfully updated' });
     }
 
     start();
@@ -117,12 +122,16 @@ exports.delete_user = (req, res, next) => {
 Detailed explanation:
 
 ```javascript
+require('app-module-path/register');
+
+const util   = require('../helpers/util');
 const mysql  = require('anytv-node-mysql');
-const util   = require('helpers/util');
+const squel  = require('squel');
 const moment = require('moment');
 ```
 
 - The first part of the controller contains the helpers, and libraries to be used by the controller's functions
+- The `app-module-path/register` module prevents the usage of `__dirname` in requiring local modules
 - Notice the order of imported files, local files first followed by 3rd-party libraries
 - This block should always be followed by at least one new line to separate them visually easily
 
@@ -167,12 +176,14 @@ exports.update_user = (req, res, next) => {
         id = data.id;
         delete data.id;
 
+        const query = squel.update()
+            .table('users')
+            .setFields(data)
+            .where('user_id = ?', id)
+            .limit(1);
+        
         mysql.use('my_db')
-            .query(
-                'UPDATE users SET ? WHERE user_id = ? LIMIT 1;',
-                [id, data],
-                send_response
-            )
+            .squel(query, send_response)
             .end();
     }
 ```
@@ -189,7 +200,7 @@ exports.update_user = (req, res, next) => {
             return next(err);
         }
 
-        res.send({message: 'User successfully updated'});
+        res.send({ message: 'User successfully updated' });
     }
 
     start();
@@ -222,13 +233,23 @@ Install the tools needed:
 npm install istanbul -g
 npm install apidoc -g
 npm install mocha -g
-npm install --dev
+npm install --only=dev
 ```
 
 ## Running test
 
 ```sh
 npm test
+# or
+grunt test
+```
+
+## Test Driven Development (TDD)
+- Use npm scripts or grunt tasks that watches the tests.
+```sh
+npm test-dev
+# or
+grunt test-watch
 ```
 
 ## Code coverage
@@ -236,14 +257,14 @@ npm test
 ```sh
 npm run coverage
 ```
-Then open coverage/lcov-report/index.html.
+Then open `coverage/lcov-report/index.html`.
 
 ## API documentation
 
 ```sh
 npm run docs
 ```
-Then open apidoc/index.html.
+Then open `apidoc/index.html`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -45,13 +45,14 @@
     "grunt": "^1.0.1",
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
+    "grunt-env": "^0.4.4",
     "grunt-express-server": "^0.5.1",
     "grunt-mocha-test": "^0.13.1",
     "istanbul": "^0.4.3",
     "mocha": "^3.0.2",
     "mocha-lcov-reporter": "^1.0.0",
-    "supertest": "^3.0.0",
-    "node-mocks-http": "^1.5.6"
+    "node-mocks-http": "^1.5.6",
+    "supertest": "^3.0.0"
   },
   "apidoc": {
     "title": "Node REST API Boilerplate",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "method-override": "^2.3.6",
     "moment": "^2.14.1",
     "morgan": "^1.7.0",
+    "squel": "^5.10.0",
     "winston": "^2.1.0",
     "winston-daily-rotate-file": "^1.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "winston-daily-rotate-file": "^1.4.3"
   },
   "scripts": {
-    "start": "grunt",
+    "dev-server": "grunt",
     "test": "grunt test",
+    "dev-tests": "grunt dev-tests",
     "coverage": "unset NODE_ENV && istanbul cover _mocha -- --recursive -R spec -t 5000 -s 100",
-    "test-dev": "grunt test-watch",
     "docs": "apidoc -i controllers -o apidoc/"
   },
   "repository": {

--- a/test/api/user.js
+++ b/test/api/user.js
@@ -6,7 +6,6 @@ const request = require('supertest');
 const config  = require(cwd + '/config/config');
 let api;
 
-require(cwd + '/server');
 api = request('http://localhost:' + config.app.PORT);
 
 

--- a/test/api/user.js
+++ b/test/api/user.js
@@ -1,13 +1,16 @@
 'use strict';
 
-const cwd     = process.cwd();
-const should  = require('chai').should();
+require('app-module-path/register');
+
+const should = require('chai').should();
 const request = require('supertest');
-const config  = require(cwd + '/config/config');
-let api;
+const server = require('../../server');
+const api = request(server.app);
 
-api = request('http://localhost:' + config.app.PORT);
 
+after('close server', function () {
+    server.handler.close();
+});
 
 describe('User', () => {
     it('should get one user', (done) => {

--- a/test/unit/app_env.js
+++ b/test/unit/app_env.js
@@ -3,13 +3,10 @@
 const config = require(process.cwd() + '/config/config');
 
 describe('App', () => {
-    it('environment should default to development environment', (done) => {
-		config.app.ENV.should.equal('development');
-		done();
-	});
-
-    it('environment should set to test environment', (done) => {
-		config.use('test').app.ENV.should.equal('test');
-		done();
-	});
+    it('environment should set to proper environment', (done) => {
+        config.use('development').app.ENV.should.equal('development');
+        config.use('production').app.ENV.should.equal('production');
+        config.use('test').app.ENV.should.equal('test');
+        done();
+    });
 });


### PR DESCRIPTION
#### Changes:
- removed deprecated option from `jshintrc`
- added `grunt-env` module
- fixed `test-watch` task in grunt

#### Ticket Reference:
- [Dev-1776](https://freedom.myjetbrains.com/youtrack/issue/Dev-1776)

#### Test:
- [ ] Setup project and run `grunt test-watch`.
  - Make some non-breaking change (Enter a newline) on any watched files. This should reload the grunt task and test cases should still pass. This should not have an `EADDRINUSE` error.
  - Make some breaking change (remove a semi-colon) on any watched files. This should reload the grunt task and an error should occur but task should not stop. This should not have an `EADDRINUSE` error.
- [ ] Do the same steps above except run `grunt` only.